### PR TITLE
add doctype and change single quotes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,9 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title>Interface</title>
   <link rel="stylesheet" type="text/css" href="style.css">
-  <link href='http://fonts.googleapis.com/css?family=Press+Start+2P' rel='stylesheet' type='text/css'>
+  <link href="http://fonts.googleapis.com/css?family=Press+Start+2P" rel="stylesheet" type="text/css">
 </head>
 <body>
   <header>


### PR DESCRIPTION
It was missing the doctype and used single quotes in a link tag.